### PR TITLE
wait before creating geometry indexes

### DIFF
--- a/imposm/app.py
+++ b/imposm/app.py
@@ -274,6 +274,11 @@ def main(argv=None):
             view_timer = imposm.util.Timer('creating views', logger)
             db.create_views(mappings)
             view_timer.stop()
+            
+            logger.message('## creating geometry indexes')
+            index_timer = imposm.util.Timer('creating indexes', logger)
+            db.post_insert(mappings);
+            index_timer.stop()
 
             db.commit()
 


### PR DESCRIPTION
The attached patch removes the geometry index creation from the create_table phase, and moves this to the optimization step. In theory, bulk loading of geometries should be faster if the index does not need to be updated at each insert.

On a highly unrigorous test on a small dataset (ireland), this patch shows no real speed improvement over the original code. It might be interesting to test it on a much larger import to see if there are some advantages in using this. Will keep you updated if you think this is worth looking into.
