### PR TITLE
Check connection before reading. Fail if unable to connect

### DIFF
--- a/imposm/app.py
+++ b/imposm/app.py
@@ -40,7 +40,7 @@ import imposm.mapping
 import imposm.util
 import imposm.version
 from imposm.writer import ImposmWriter
-from imposm.db.config import DB
+from imposm.db.config import DB, check_connection
 from imposm.cache import OSMCache
 from imposm.reader import ImposmReader
 from imposm.mapping import TagMapper
@@ -244,6 +244,12 @@ def main(argv=None):
         if not args:
             print "no file(s) supplied"
             sys.exit(2)
+
+        if options.write:
+            err = check_connection(db_conf)
+            if err:
+                logger.message("WARNING: unable to connect to database.\n{0}".format(err))
+                sys.exit(2)
 
         reader = ImposmReader(tag_mapping, cache=cache, merge=options.merge_cache,
             pool_size=options.concurrency, logger=logger_parser)

--- a/imposm/app.py
+++ b/imposm/app.py
@@ -248,7 +248,7 @@ def main(argv=None):
         if options.write:
             err = check_connection(db_conf)
             if err:
-                logger.message("WARNING: unable to connect to database.\n{0}".format(err))
+                logger.message("ERROR: unable to connect to database. Check your DB settings.\n{0}".format(err))
                 sys.exit(2)
 
         reader = ImposmReader(tag_mapping, cache=cache, merge=options.merge_cache,

--- a/imposm/db/config.py
+++ b/imposm/db/config.py
@@ -25,6 +25,13 @@ def DB(db_conf):
         return PostGISDB(db_conf)
     raise ValueError('unknown db: %s' % (db_conf.name,))
 
+def check_connection(db_conf):
+    try:
+        db = DB(db_conf)
+        db.connection
+    except Exception, e:
+        return e
+
 def db_conf_from_string(conf, base_db_conf):
     db_conf = _parse_rfc1738_args(conf)
     if 'proj' not in db_conf:


### PR DESCRIPTION
The motivation for this is that, if you set imposm to a long read, you may not be around when it finishes. If somebody starts up imposm with a read and a write, make sure we can at least connect to the DB before beginning the write.

If we can't connect, print the error and quit so the user can either remove the write option or fix his DB parameters.
