### PR TITLE
Tell a user that they can use the extant cache to write

### DIFF
--- a/imposm/app.py
+++ b/imposm/app.py
@@ -229,7 +229,9 @@ def main(argv=None):
                 if not options.overwrite_cache:
                     print (
                         "ERROR: found existing cache files in '%s'. "
-                        'remove files or use --overwrite-cache or --merge-cache.'
+                        'Remove --read option to use the existing cache '
+                        'or use --overwrite-cache or --merge-cache to '
+                        'overwrite or merge them.'
                         % os.path.abspath(options.cache_dir)
                     )
                     sys.exit(2)

--- a/imposm/app.py
+++ b/imposm/app.py
@@ -231,7 +231,7 @@ def main(argv=None):
                         "ERROR: found existing cache files in '%s'. "
                         'Remove --read option to use the existing cache '
                         'or use --overwrite-cache or --merge-cache to '
-                        'overwrite or merge them.'
+                        'overwrite or merge it.'
                         % os.path.abspath(options.cache_dir)
                     )
                     sys.exit(2)


### PR DESCRIPTION
I have several times regenerated cache files when imposm failed on writing, because I didn't know that I could simply remove the --read option.

This patch simply tells the user that they have the option of removing the --read flag to use the cache that has already been generated so that hopefully somebody doesn't waste time like I did.
