### PR TITLE
allow tables without prefix - check if prefix is empty

### DIFF
--- a/imposm/db/postgis.py
+++ b/imposm/db/postgis.py
@@ -47,7 +47,9 @@ class PostGISDB(object):
 
     @property
     def table_prefix(self):
-        return self.db_conf.prefix.rstrip('_') + '_'
+        if self.db_conf.prefix:
+            return self.db_conf.prefix.rstrip('_') + '_'
+        return self.db_conf.prefix
 
     def to_tablename(self, name):
         return self.table_prefix + name.lower()


### PR DESCRIPTION
Currently it is not possible to use an empty prefix.
