### PR TITLE
Add support for PostgreSQL HSTORE

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -77,6 +77,14 @@ There is a default field for names if you do not supply a field for the `name` c
 .. autofunction:: set_default_name_type
 
 
+PostgreSQL hstore
+^^^^^^^^^^^^^^^^^
+
+By default each mapping only stores the fields that are specified in the `tags` hstore column. If you want to store all OSM tags can call :func:`set_hstore_all_tags`.
+
+.. autofunction:: set_hstore_all_tags
+
+
 Classes
 ~~~~~~~
 

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -27,6 +27,9 @@ There are three classes for the base geometries: ``Points``, ``LineStrings``  an
 ``with_type_field``
   Controls if the the *value* of the mapped key/value should be stored in the ``type`` column. Defaults to ``True``.
 
+``use_hstore``
+  Controls if all tags should be stored in a ``tags`` hstore column. Defaults to ``False``
+
 .. _mapping:
 
 mapping

--- a/imposm/mapping.py
+++ b/imposm/mapping.py
@@ -39,9 +39,11 @@ __all__ = [
     'FixInvalidPolygons',
     'UnionView',
     'set_default_name_field',
+    'set_hstore_all_tags'
 ]
 
 default_name_field = None
+hstore_all_tags = False
 
 def set_default_name_type(type, column_name='name'):
     """
@@ -54,6 +56,17 @@ def set_default_name_type(type, column_name='name'):
     """
     global default_name_field
     default_name_field = column_name, type
+
+def set_hstore_all_tags(all_tags):
+    """
+    Set flag that indicates that we should disable the filtering of tags.
+
+    ::
+
+        set_hstore_all_tags(True)
+    """
+    global hstore_all_tags
+    hstore_all_tags = all_tags
 
 # changed by imposm.app if the projection is epsg:4326
 import_srs_is_geographic = False
@@ -227,6 +240,10 @@ class TagMapper(object):
         return self._mapping_for_tags(self.polygon_mappings, tags)
 
     def _tag_filter(self, filter_tags):
+        # Disable filtering of tags by returning None.
+        if hstore_all_tags:
+            return None
+
         def filter(tags):
             for k in tags.keys():
                 if k not in filter_tags:
@@ -271,7 +288,8 @@ class TagMapper(object):
                 tags.clear()
                 return
             tag_count = len(tags)
-            _rel_filter(tags)
+            if _rel_filter is not None:
+                _rel_filter(tags)
             if len(tags) < tag_count:
                 # we removed tags...
                 if not set(tags).difference(expected_tags):

--- a/imposm/mapping.py
+++ b/imposm/mapping.py
@@ -87,10 +87,12 @@ class Mapping(object):
     _insert_stmt = None
     with_type_field = True
 
-    def __init__(self, name, mapping, fields=None, field_filter=None, with_type_field=None):
+    def __init__(self, name, mapping, fields=None, field_filter=None, with_type_field=None,
+                 use_hstore = False):
         self.name = name
         self.mapping = mapping
         self.fields = fields or tuple(self.fields)
+        self.use_hstore = use_hstore
         self.limit_to_polygon = None
         if with_type_field is not None:
             # allow subclass to define other default by setting it as class variable
@@ -154,12 +156,19 @@ class Mapping(object):
             raise DropElem(ex)
 
     def field_values(self, osm_elem):
-        return [t.value(osm_elem.tags.get(n), osm_elem) for n, t in self.fields]
+        values = [t.value(osm_elem.tags.get(n), osm_elem) for n, t in self.fields]
+        # Add dictionary of all tags which will be converted by psycopg2.
+        if self.use_hstore:
+            values.append(osm_elem.tags)
+        return values
 
     def field_dict(self, osm_elem):
         result = dict((n, t.value(osm_elem.tags.get(n), osm_elem)) for n, t in self.fields)
         if self.with_type_field:
             del result['type']
+        # Add dictionary of all tags which will be converted by psycopg2.
+        if self.use_hstore:
+            result['tags'] = osm_elem.tags
         result[osm_elem.cls] = osm_elem.type
         return result
 

--- a/imposm/psqldb.py
+++ b/imposm/psqldb.py
@@ -24,6 +24,7 @@ createuser --no-superuser --no-createrole --createdb ${user}
 createdb -E UTF8 -O ${user} ${dbname}
 createlang plpgsql ${dbname}
 ${postgis}
+echo "CREATE EXTENSION hstore;" | psql -d ${dbname}
 echo "ALTER TABLE spatial_ref_sys OWNER TO ${user};" | psql -d ${dbname}
 echo "ALTER USER ${user} WITH PASSWORD '${password}';" |psql -d ${dbname}
 echo "host\t${dbname}\t${user}\t127.0.0.1/32\tmd5" >> ${pg_hba}


### PR DESCRIPTION
This adds a `use_hstore` parameter that will cause all OSM tags to be added to a hstore `tags` column. This can be useful when you want to query the features for all available data.
