### PR TITLE
Feat route relations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Changelog
 unreleased
 ~~~~~~~~~~
 - add possibility to import route relations
+- add possibility to use ":" and similar characters in tag/column
+  names when generalizing such tables
 
 2.5.0 2012-12-06
 ~~~~~~~~~~~~~~~~

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+unreleased
+~~~~~~~~~~
+- add possibility to import route relations
+
 2.5.0 2012-12-06
 ~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,12 @@
+This fork extends the original `imposm` by
+
+* possibility to import route relations
+
+The changes are inspired by those published by `michalmacki <https://bitbucket.org/michalmacki/imposm-routes/>`_.
+As those seem to be based on an outdated imposm, they are contained in an hg
+repository instead of git, and I saw the need for some slight changes, I
+replicated several of his changes.
+
 Imposm is an importer for OpenStreetMap data. It reads XML and PBF files and
 can import the data into PostgreSQL/PostGIS databases.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 This fork extends the original `imposm` by
 
 * possibility to import route relations
+* allow ":" and similar characters in tag names when creating generalized tables
 
 The changes are inspired by those published by `michalmacki <https://bitbucket.org/michalmacki/imposm-routes/>`_.
 As those seem to be based on an outdated imposm, they are contained in an hg

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,9 @@ This fork extends the original `imposm` by
 
 The changes are inspired by those published by `michalmacki <https://bitbucket.org/michalmacki/imposm-routes/>`_.
 As those seem to be based on an outdated imposm, they are contained in an hg
-repository instead of git, and I saw the need for some slight changes, I
-replicated several of his changes.
+repository instead of git, and I saw the need for some slight changes (most
+notably support of routes in the ContainsRelationBuilder, not just
+UnionRelationBuilder), I replicated several of his changes.
 
 Imposm is an importer for OpenStreetMap data. It reads XML and PBF files and
 can import the data into PostgreSQL/PostGIS databases.

--- a/imposm/db/postgis.py
+++ b/imposm/db/postgis.py
@@ -421,7 +421,7 @@ class PostGISUnionView(object):
 
         for mapping in self.mapping.mappings:
             field_str = ', '.join(self._mapping_fields(mapping))
-            selects.append("""SELECT %s osm_id, geometry, "%s",
+            selects.append("""SELECT %s osm_id, geometry, %s,
                 '%s' as class from "%s" """ % (
                 serial_column, field_str,
                 mapping.classname or mapping.name, self.db.to_tablename(mapping.name)))
@@ -484,7 +484,7 @@ class PostGISGeneralizedTable(object):
         return stmt
 
     def _stmt(self):
-        fields = ', '.join(["'"+n+'"' for n, t in self.mapping.fields])
+        fields = ', '.join(['"'+n+'"' for n, t in self.mapping.fields])
         if fields:
             fields += ','
 

--- a/imposm/db/postgis.py
+++ b/imposm/db/postgis.py
@@ -421,7 +421,7 @@ class PostGISUnionView(object):
 
         for mapping in self.mapping.mappings:
             field_str = ', '.join(self._mapping_fields(mapping))
-            selects.append("""SELECT %s osm_id, geometry, %s,
+            selects.append("""SELECT %s osm_id, geometry, "%s",
                 '%s' as class from "%s" """ % (
                 serial_column, field_str,
                 mapping.classname or mapping.name, self.db.to_tablename(mapping.name)))
@@ -484,7 +484,7 @@ class PostGISGeneralizedTable(object):
         return stmt
 
     def _stmt(self):
-        fields = ', '.join([n for n, t in self.mapping.fields])
+        fields = ', '.join(["'"+n+'"' for n, t in self.mapping.fields])
         if fields:
             fields += ','
 

--- a/imposm/dbimporter.py
+++ b/imposm/dbimporter.py
@@ -260,7 +260,9 @@ class RelationProcess(ImporterProcess):
                 break
 
             for relation in relations:
+
                 builder = RelationBuilder(relation, ways_cache, coords_cache)
+
                 try:
                     builder.build()
                 except IncompletePolygonError, ex:
@@ -270,7 +272,7 @@ class RelationProcess(ImporterProcess):
                 mappings = self.mapper.for_relations(relation.tags)
                 if mappings:
                     inserted = self.insert(mappings, relation.osm_id, relation.geom, relation.tags)
-                    if inserted and any(getattr(m, 'skip_inserted_ways', False) for _, m in mappings):
+                    if inserted and any(getattr(m, 'skip_inserted_ways', False) for _, ms in mappings for m in ms):
                         builder.mark_inserted_ways(self.inserted_way_queue)
 
 class RelationProcessDict(RelationProcess, DictBasedImporter):

--- a/imposm/defaultmapping.py
+++ b/imposm/defaultmapping.py
@@ -250,6 +250,7 @@ routes = LineStrings(
     name = 'routes',
     fields = (
         ('name', String()),
+        ('network', String()),
         ('colour', String()),
         ('color', String()),
         ('ref', String()),

--- a/imposm/defaultmapping.py
+++ b/imposm/defaultmapping.py
@@ -246,6 +246,22 @@ aeroways = LineStrings(
     )}
 )
 
+routes = LineStrings(
+    name = 'routes',
+    fields = (
+        ('name', String()),
+        ('colour', String()),
+        ('color', String()),
+        ('ref', String()),
+        ('operator', String()),
+        ('osmc:symbol', String()),
+    ),
+    mapping = {
+        'route': (
+            '__any__',
+    )}
+)
+
 transport_areas = Polygons(
     name = 'transport_areas',
     mapping = {

--- a/imposm/geom.py
+++ b/imposm/geom.py
@@ -15,8 +15,6 @@
 from __future__ import division
 
 import math
-import codecs
-import os
 import shapely.geometry
 import shapely.geos
 import shapely.prepared
@@ -32,7 +30,7 @@ except ImportError:
     rtree = None
 
 from imposm import config
-from imposm.util.geom import load_polygons, load_datasource, build_multipolygon
+from imposm.util.geom import load_datasource, build_multipolygon
 
 import logging
 log = logging.getLogger(__name__)
@@ -166,8 +164,8 @@ class LineStringBuilder(GeomBuilder):
         return 'LINESTRING(' + ', '.join('%f %f' % p for p in data) + ')'
 
     def check_geom_type(self, geom):
-        if geom.type != 'LineString':
-            raise InvalidGeometryError('expected LineString, got %s' % geom.type)
+        if geom.type not in ('LineString', 'MultiLineString'):
+            raise InvalidGeometryError('expected LineString or MultiLineString, got %s' % geom.type)
 
     def to_geom(self, data, max_length=None):
         if len(data) <= 1:
@@ -178,7 +176,7 @@ class LineStringBuilder(GeomBuilder):
             max_length = config.imposm_linestring_max_length
         if max_length and len(data) > max_length:
             chunks = math.ceil(len(data) / max_length)
-            length = int(len(data) // chunks)
+            length = int((len(data)-1) // chunks) + 1
             lines = []
             for i in xrange(1, len(data), length):
                 lines.append(geometry.LineString(data[i-1:i+length]))

--- a/imposm/mapping.py
+++ b/imposm/mapping.py
@@ -253,6 +253,8 @@ class TagMapper(object):
             tags.setdefault(k, set()).update(v)
         for k, v in self.polygon_tags.iteritems():
             tags.setdefault(k, set()).update(v)
+        for k, v in {'type': set(['multipolygon', 'boundary', 'land_area'])}.iteritems():
+            tags.setdefault(k, set()).update(v)
         return self._tag_filter(tags)
         
         #tags['type'] = set(['multipolygon', 'boundary', 'land_area'])  # for type=multipolygon

--- a/imposm/multipolygon.py
+++ b/imposm/multipolygon.py
@@ -80,19 +80,23 @@ class RelationBuilderBase(object):
     def build_rings(self, ways):
         rings = []
         incomplete_rings = []
+        linestring_rings = []
         
         for ring in (Ring(w) for w in ways):
             if ring.is_closed():
                 ring.geom = self.polygon_builder.build_checked_geom(ring, validate=self.validate_rings)
                 rings.append(ring)
+            elif 'route' in self.relation.tags:
+                ring.geom = self.linestring_builder.build_geom(ring)
+                linestring_rings.append(ring)
             else:
                 incomplete_rings.append(ring)
         
         merged_rings = self.build_ring_from_incomplete(incomplete_rings)
-        if len(rings) + len(merged_rings) == 0:
+        if len(rings) + len(merged_rings) + len(linestring_rings) == 0:
             raise IncompletePolygonError('linestrings from relation %s have no rings' % (self.relation.osm_id, ))
         
-        return rings + merged_rings
+        return rings + merged_rings + linestring_rings
         
     def build_ring_from_incomplete(self, incomplete_rings):
         

--- a/imposm/multipolygon.py
+++ b/imposm/multipolygon.py
@@ -230,8 +230,8 @@ class ContainsRelationBuilder(RelationBuilderBase):
         """
         islines = ('route' in self.relation.tags)
         #islines = all(ring.geom.geom_type in ('LineString', 'MultiLineString') for ring in rings)
-        import sys
-        sys.printf("*** ContainsRelationBuilder.build_relation_geometry: Relation %r, found feature types: %r" % ( self.relation.tags, [ring.geom.geom_type in ('LineString', 'MultiLineString') for ring in rings] ) )
+        #import sys
+        #sys.stderr.write("*** ContainsRelationBuilder.build_relation_geometry: Relation %r, found feature types: %r\n" % ( self.relation.tags, [ring.geom.geom_type for ring in rings] ) )
         if islines:
             self.relation.geom = shapely.ops.linemerge([ring.geom for ring in rings])
             for ring in rings:

--- a/imposm/multipolygon.py
+++ b/imposm/multipolygon.py
@@ -83,12 +83,12 @@ class RelationBuilderBase(object):
         linestring_rings = []
         
         for ring in (Ring(w) for w in ways):
-            if ring.is_closed():
-                ring.geom = self.polygon_builder.build_checked_geom(ring, validate=self.validate_rings)
-                rings.append(ring)
-            elif 'route' in self.relation.tags:
+            if 'route' in self.relation.tags:
                 ring.geom = self.linestring_builder.build_geom(ring)
                 linestring_rings.append(ring)
+            elif ring.is_closed():
+                ring.geom = self.polygon_builder.build_checked_geom(ring, validate=self.validate_rings)
+                rings.append(ring)
             else:
                 incomplete_rings.append(ring)
         


### PR DESCRIPTION
Dear imposm 2.5 maintainers,

I have worked on some modifications to imposm (version 2.5) in my branch at https://github.com/numenor/imposm/tree/feat-route-relations . I am aware of it not cleanly applying on your master currently (although I am a bit confused because of the history of master git is showing me; but more about that if you think my changes to be relevant).

I am wondering whether you are interested in the features implemented by me (and michalmacki https://bitbucket.org/michalmacki/imposm-routes/overview , on whose work mine is based), and whether it is worth the effort of sorting out the remaining issues (rebasing my branch on your current master, and probably removing one conflict where we have both done a similar change in postgis.py -> _stmt).

The features in short:
- support route relations
- support ":" characters in tag names

I have tested my branch on renderings with an own style, on an imposm import of the whole of Austria, and it seems fine. But I suggest that someone with better knowledge about the internals of imposm reviews my changes, because in mapping.py -> TagMapper.tag_filter_for_relations I now let all relations pass, as long as they have some key/value pairs requested by the mapping configuration (not only multipolygons/boundaries/land_area as originally, and not only routes which were my original motivation).

Best wishes, Holger Schöner (numenor at github, numenor@ancalime.de)
